### PR TITLE
added the onRequestClose property for the modal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ export default class ModalFilterPicker extends Component {
     )
 
     return (
-      <Modal {...modal} visible={visible} supportedOrientations={['portrait', 'landscape']}>
+      <Modal {...modal} visible={visible} onRequestClose={this.props.onCancel} supportedOrientations={['portrait', 'landscape']}>
         <View style={overlayStyle || styles.overlay}>
           {renderedTitle}
           {(renderList || this.renderList)()}


### PR DESCRIPTION
Using expo, I noticed that I got a yellow box warning regarding that a Modal should have the onRequestClose property. This PR sets the onRequestClose property equal to onCancel, so when the back button is pressed the onClose function is being called.