### PR TITLE
add optionTextStyle to style props documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ In addition, the following styling props (each of which must be an `Object` cons
 | `cancelButtonStyle` | Style for the cancel button button face |
 | `cancelButtonTextStyle` | Style for the cancel button text |
 | `titleTextStyle` | Style for the title text |
+| `optionTextStyle` | Style for the option text |
 
 ## Advanced filtering
 

--- a/src/index.js
+++ b/src/index.js
@@ -136,7 +136,7 @@ export default class ModalFilterPicker extends Component {
     const {
       selectedOption,
       renderOption,
-        optionTextStyle,
+      optionTextStyle,
       selectedOptionTextStyle
     } = this.props
 


### PR DESCRIPTION
Hi @hiddentao,

According to the source code, `ModalFilterPicker` can take an optional `optionTextStyle` to style the option text, but this is not documented in the README. This PR adds that documentation. (Resolves #15).

Jason