### PR TITLE
Update componentWillReceiveProps.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,15 +30,15 @@ export default class ModalFilterPicker extends Component {
     }
   }
 
-  componentWillReceiveProps(newProps) {
+  static getDerivedStateFromProps(newProps, prevProps) {
     if (
-      (!this.props.visible && newProps.visible) ||
-      this.props.options !== newProps.options
+      (!prevProps.visible && newProps.visible) ||
+      prevProps.options !== newProps.options
     ) {
-      this.setState({
+      return {
         filter: "",
         ds: newProps.options
-      })
+      }
     }
   }
 


### PR DESCRIPTION
componentWillReceiveProps will be deprecated and causes the following warning: 

```
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: ModalFilterPicker
- node_modules/expo/build/logs/LogSerialization.js:166:14 in _captureConsoleStackTrace
- node_modules/expo/build/logs/LogSerialization.js:41:24 in serializeLogDataAsync
- ... 9 more stack frames from framework internals
```