### PR TITLE
[Cleanup] Remove remnants of ListView & variable rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Features:
 * Default styling works well
 * Extensively customisable styling and rendering
 * Built-in search filter for long lists
-* Uses React Native `ListView` for lazy-loading and high performance
+* Uses React Native `FlatList` for lazy-loading and high performance
 * Compatible with React Native 0.40+
 * Successfully used in production apps
 
@@ -123,7 +123,7 @@ The following functionality props can be passed to the component:
 | `showFilter` | `Boolean` | `true` | Whether to show filter text field field or not |
 | `modal` | `Object` | `null` | Options to pass to native `Modal` component |
 | `selectedOption` | `String` | `null` | The currently selected option, to visually differentiate it from others |
-| `listViewProps` | `Object` | `null` | Properties to pass to the rendered `ListView` |
+| `flatListProps` | `Object` | `null` | Properties to pass to the rendered `FlatList` |
 | `renderOption` | `function (option, isSelected) {}` | `null` | Custom option renderer |
 | `renderList` | `function () {}` | `null` | Custom option list renderer |
 | `renderCancelButton` | `function () {}` | `null` | Custom cancel button renderer |

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ export default class ModalFilterPicker extends Component {
   renderOptionList = () => {
     const {
       noResultsText,
-      flatListViewProps,
+      flatListProps,
       keyExtractor,
       keyboardShouldPersistTaps
     } = this.props
@@ -136,7 +136,7 @@ export default class ModalFilterPicker extends Component {
         <FlatList
           data={ds}
           keyExtractor={keyExtractor || this.constructor.keyExtractor}
-          {...flatListViewProps}
+          {...flatListProps}
           renderItem={() => (
             <View style={styles.noResults}>
               <Text style={styles.noResultsText}>{noResultsText}</Text>
@@ -148,7 +148,7 @@ export default class ModalFilterPicker extends Component {
     return (
       <FlatList
         keyExtractor={keyExtractor || this.constructor.keyExtractor}
-        {...flatListViewProps}
+        {...flatListProps}
         data={ds}
         renderItem={this.renderOption}
         keyboardShouldPersistTaps={keyboardShouldPersistTaps}
@@ -248,7 +248,7 @@ ModalFilterPicker.propTypes = {
   renderOption: PropTypes.func,
   renderCancelButton: PropTypes.func,
   renderList: PropTypes.func,
-  flatListViewProps: PropTypes.object,
+  flatListProps: PropTypes.object,
   filterTextInputContainerStyle: PropTypes.any,
   filterTextInputStyle: PropTypes.any,
   cancelContainerStyle: PropTypes.any,


### PR DESCRIPTION
This pull request:
- updates documentation to reflect changes of https://github.com/hiddentao/react-native-modal-filter-picker/pull/40
- renames variable **flatListViewProps** to **flatListProps** 

@hiddentao let me know if I can improve somehow this pull request